### PR TITLE
Change org to orgName and fix macro type

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -2265,16 +2265,10 @@ export interface QueryMacroProperties {
     type?: QueryMacroProperties.TypeEnum;
     /**
      * 
-     * @type {string}
+     * @type {QueryMacroPropertiesValues}
      * @memberof QueryMacroProperties
      */
-    query?: string;
-    /**
-     * 
-     * @type {string}
-     * @memberof QueryMacroProperties
-     */
-    queryType?: string;
+    values?: QueryMacroPropertiesValues;
 }
 
 /**
@@ -2289,6 +2283,26 @@ export namespace QueryMacroProperties {
     export enum TypeEnum {
         Query = 'query'
     }
+}
+
+/**
+ * 
+ * @export
+ * @interface QueryMacroPropertiesValues
+ */
+export interface QueryMacroPropertiesValues {
+    /**
+     * 
+     * @type {string}
+     * @memberof QueryMacroPropertiesValues
+     */
+    query?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof QueryMacroPropertiesValues
+     */
+    language?: string;
 }
 
 /**
@@ -3293,7 +3307,13 @@ export interface TaskCreateRequest {
      * @type {string}
      * @memberof TaskCreateRequest
      */
-    orgID: string;
+    orgID?: string;
+    /**
+     * The name of the organization that owns this Task.
+     * @type {string}
+     * @memberof TaskCreateRequest
+     */
+    org?: string;
     /**
      * Starting state of the task. 'inactive' tasks are not run until they are updated to 'active'
      * @type {string}

--- a/src/wrappers/buckets.ts
+++ b/src/wrappers/buckets.ts
@@ -13,8 +13,8 @@ export default class {
     return data;
   }
 
-  public async getAllByOrg({name}: Organization): Promise<Bucket[]> {
-    const {data: {buckets}} = await this.service.bucketsGet(name);
+  public async getAllByOrg(org: string): Promise<Bucket[]> {
+    const {data: {buckets}} = await this.service.bucketsGet(undefined, undefined, undefined, org);
 
     return buckets || [];
   }

--- a/src/wrappers/tasks.ts
+++ b/src/wrappers/tasks.ts
@@ -20,8 +20,8 @@ export default class {
     return data;
   }
 
-  public async getAllByOrg({name}: Organization): Promise<Task[]> {
-    const {data: {tasks}} = await this.service.tasksGet(undefined, undefined, undefined, name);
+  public async getAllByOrg(org: string): Promise<Task[]> {
+    const {data: {tasks}} = await this.service.tasksGet(undefined, undefined, undefined, org);
 
     return tasks || [];
   }

--- a/src/wrappers/variables.ts
+++ b/src/wrappers/variables.ts
@@ -7,8 +7,8 @@ export default class {
     this.service = new MacrosApi({basePath});
   }
 
-  public async getAllByOrg(orgName: string): Promise<Macro[]> {
-    const {data: {macros}} = await this.service.macrosGet(undefined, orgName);
+  public async getAllByOrg(org: string): Promise<Macro[]> {
+    const {data: {macros}} = await this.service.macrosGet(undefined, org);
 
     return macros || [];
   }


### PR DESCRIPTION
This PR fixes the Macro type to match the implementation. A `value` property is added to the `QueryMacroProperties` object type, and the `queryType` property is renamed to `language`.

It also changes the parameters for buckets and tasks to use the organization name string rather than 
the entire organization object.