### PR TITLE
Add function to get all variables from all orgs

### DIFF
--- a/src/wrappers/variables.ts
+++ b/src/wrappers/variables.ts
@@ -26,6 +26,12 @@ export default class {
     return variables || [];
   }
 
+  public async getAll(): Promise<Variable[]> {
+    const {data: {variables}} = await this.service.variablesGet();
+
+    return variables || [];
+  }
+
   public async create(variable: Variable): Promise<Variable> {
     const {data} = await this.service.variablesPost(variable);
 


### PR DESCRIPTION
This PR adds a function, `getAll` to fetch all variables from all organizations.