### PR TITLE
Regenerate client

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -3222,12 +3222,6 @@ export interface Task {
      */
     name: string;
     /**
-     * 
-     * @type {User}
-     * @memberof Task
-     */
-    owner?: User;
-    /**
      * The current status of the task. When updated to 'inactive', cancels all queued jobs of this task.
      * @type {string}
      * @memberof Task
@@ -5207,6 +5201,12 @@ export interface TelegrafRequest {
      * @memberof TelegrafRequest
      */
     name?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof TelegrafRequest
+     */
+    description?: string;
     /**
      * 
      * @type {TelegrafRequestAgent}
@@ -16366,19 +16366,19 @@ export const TasksApiAxiosParamCreator = function (configuration?: Configuration
          * Update a task. This will cancel all queued runs.
          * @summary Update a task
          * @param {string} taskID ID of task to get
-         * @param {Task} task task update to apply
+         * @param {TaskUpdateRequest} taskUpdateRequest task update to apply
          * @param {string} [zapTraceSpan] OpenTracing span context
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        tasksTaskIDPatch(taskID: string, task: Task, zapTraceSpan?: string, options: any = {}): RequestArgs {
+        tasksTaskIDPatch(taskID: string, taskUpdateRequest: TaskUpdateRequest, zapTraceSpan?: string, options: any = {}): RequestArgs {
             // verify required parameter 'taskID' is not null or undefined
             if (taskID === null || taskID === undefined) {
                 throw new RequiredError('taskID','Required parameter taskID was null or undefined when calling tasksTaskIDPatch.');
             }
-            // verify required parameter 'task' is not null or undefined
-            if (task === null || task === undefined) {
-                throw new RequiredError('task','Required parameter task was null or undefined when calling tasksTaskIDPatch.');
+            // verify required parameter 'taskUpdateRequest' is not null or undefined
+            if (taskUpdateRequest === null || taskUpdateRequest === undefined) {
+                throw new RequiredError('taskUpdateRequest','Required parameter taskUpdateRequest was null or undefined when calling tasksTaskIDPatch.');
             }
             const localVarPath = `/tasks/{taskID}`
                 .replace(`{${"taskID"}}`, encodeURIComponent(String(taskID)));
@@ -16401,8 +16401,8 @@ export const TasksApiAxiosParamCreator = function (configuration?: Configuration
             // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = Object.assign({}, localVarHeaderParameter, options.headers);
-            const needsSerialization = (<any>"Task" !== "string") || localVarRequestOptions.headers['Content-Type'] === 'application/json';
-            localVarRequestOptions.data =  needsSerialization ? JSON.stringify(task || {}) : (task || "");
+            const needsSerialization = (<any>"TaskUpdateRequest" !== "string") || localVarRequestOptions.headers['Content-Type'] === 'application/json';
+            localVarRequestOptions.data =  needsSerialization ? JSON.stringify(taskUpdateRequest || {}) : (taskUpdateRequest || "");
 
             return {
                 url: url.format(localVarUrlObj),
@@ -16869,13 +16869,13 @@ export const TasksApiFp = function(configuration?: Configuration) {
          * Update a task. This will cancel all queued runs.
          * @summary Update a task
          * @param {string} taskID ID of task to get
-         * @param {Task} task task update to apply
+         * @param {TaskUpdateRequest} taskUpdateRequest task update to apply
          * @param {string} [zapTraceSpan] OpenTracing span context
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        tasksTaskIDPatch(taskID: string, task: Task, zapTraceSpan?: string, options?: any): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<Task> {
-            const localVarAxiosArgs = TasksApiAxiosParamCreator(configuration).tasksTaskIDPatch(taskID, task, zapTraceSpan, options);
+        tasksTaskIDPatch(taskID: string, taskUpdateRequest: TaskUpdateRequest, zapTraceSpan?: string, options?: any): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<Task> {
+            const localVarAxiosArgs = TasksApiAxiosParamCreator(configuration).tasksTaskIDPatch(taskID, taskUpdateRequest, zapTraceSpan, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = Object.assign(localVarAxiosArgs.options, {url: basePath + localVarAxiosArgs.url})
                 return axios.request(axiosRequestArgs);                
@@ -17139,13 +17139,13 @@ export const TasksApiFactory = function (configuration?: Configuration, basePath
          * Update a task. This will cancel all queued runs.
          * @summary Update a task
          * @param {string} taskID ID of task to get
-         * @param {Task} task task update to apply
+         * @param {TaskUpdateRequest} taskUpdateRequest task update to apply
          * @param {string} [zapTraceSpan] OpenTracing span context
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        tasksTaskIDPatch(taskID: string, task: Task, zapTraceSpan?: string, options?: any) {
-            return TasksApiFp(configuration).tasksTaskIDPatch(taskID, task, zapTraceSpan, options)(axios, basePath);
+        tasksTaskIDPatch(taskID: string, taskUpdateRequest: TaskUpdateRequest, zapTraceSpan?: string, options?: any) {
+            return TasksApiFp(configuration).tasksTaskIDPatch(taskID, taskUpdateRequest, zapTraceSpan, options)(axios, basePath);
         },
         /**
          * 
@@ -17414,14 +17414,14 @@ export class TasksApi extends BaseAPI {
      * Update a task. This will cancel all queued runs.
      * @summary Update a task
      * @param {string} taskID ID of task to get
-     * @param {Task} task task update to apply
+     * @param {TaskUpdateRequest} taskUpdateRequest task update to apply
      * @param {string} [zapTraceSpan] OpenTracing span context
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof TasksApi
      */
-    public tasksTaskIDPatch(taskID: string, task: Task, zapTraceSpan?: string, options?: any) {
-        return TasksApiFp(this.configuration).tasksTaskIDPatch(taskID, task, zapTraceSpan, options)(this.axios, this.basePath);
+    public tasksTaskIDPatch(taskID: string, taskUpdateRequest: TaskUpdateRequest, zapTraceSpan?: string, options?: any) {
+        return TasksApiFp(this.configuration).tasksTaskIDPatch(taskID, taskUpdateRequest, zapTraceSpan, options)(this.axios, this.basePath);
     }
 
     /**


### PR DESCRIPTION
The result of running `npm run generate`. This to get the `description` field added to the `TelegrafRequest` typing.