### PR TITLE
Fix duplicating labels

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -151,7 +151,7 @@ interface IDashboardTemplateData extends ITemplateData {
   };
 }
 
-type IDashboardTemplateIncluded =
+export type IDashboardTemplateIncluded =
   | ICellIncluded
   | IViewIncluded
   | ILabelIncluded;

--- a/src/wrappers/dashboards.ts
+++ b/src/wrappers/dashboards.ts
@@ -281,13 +281,13 @@ export default class {
       throw new Error("Can not add labels to undefined Dashboard");
     }
 
-    const { content: {data: {relationships}, included} } = template;
+    const { content: {included} } = template;
 
-    if (!relationships || !relationships[TemplateType.Label]) {
+    if (!included || !included.length) {
       return;
     }
 
-    const labelsIncluded = this.findIncludedLabels(included || []);
+    const labelsIncluded = this.findIncludedLabels(included);
 
     const {data: {labels}} = await this.labelsService.labelsGet();
     const existingLabels = labels || [];

--- a/src/wrappers/dashboards.ts
+++ b/src/wrappers/dashboards.ts
@@ -161,7 +161,7 @@ export default class {
     );
 
     if (!data.label) {
-      throw new Error("Failed to create label");
+      throw new Error("Failed to add label");
     }
 
     return addLabelDefaults(data.label);


### PR DESCRIPTION
When creating a dashboard or task from a template, their labels should only get created if they dont already exist.
Additionally, addLabel, addLabels, and removeLabel in Tasks wrapper should take the label id rather than the entire label itself like in dashboards.