### PR TITLE
Update tasks removeLabels to take labelIDs instead of labels array

### DIFF
--- a/src/wrappers/tasks.ts
+++ b/src/wrappers/tasks.ts
@@ -132,8 +132,8 @@ export default class {
     return Promise.all(promises);
   }
 
-  public removeLabels(taskID: string, labels: ILabel[]): Promise<Response[]> {
-    const promises = labels.map((l) => this.removeLabel(taskID, l.id || ""));
+  public removeLabels(taskID: string, labelIDs: string[]): Promise<Response[]> {
+    const promises = labelIDs.map((l) => this.removeLabel(taskID, l));
 
     return Promise.all(promises);
   }


### PR DESCRIPTION
Make the removeLabels arguments match addLabels, addLabel, and removeLabel for the task wrapper