### PR TITLE
Derive template types from Document swagger definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@influxdata/influx",
-  "version": "0.2.40",
+  "version": "0.2.41",
   "description": "Influxdb v2 client",
   "main": "dist/index.js",
   "scripts": {

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1178,25 +1178,25 @@ export interface Document {
      * @type {string}
      * @memberof Document
      */
-    id?: string;
+    id: string;
     /**
      * 
      * @type {DocumentMeta}
      * @memberof Document
      */
-    meta?: DocumentMeta;
+    meta: DocumentMeta;
     /**
      * 
      * @type {any}
      * @memberof Document
      */
-    content?: any;
+    content: any;
     /**
      * 
      * @type {Array<Label>}
      * @memberof Document
      */
-    labels?: Array<Label>;
+    labels: Array<Label>;
 }
 
 /**
@@ -1210,13 +1210,13 @@ export interface DocumentCreate {
      * @type {DocumentMeta}
      * @memberof DocumentCreate
      */
-    meta?: DocumentMeta;
+    meta: DocumentMeta;
     /**
      * 
      * @type {any}
      * @memberof DocumentCreate
      */
-    content?: any;
+    content: any;
     /**
      * must specify one of orgID and org
      * @type {string}
@@ -1248,19 +1248,19 @@ export interface DocumentListEntry {
      * @type {string}
      * @memberof DocumentListEntry
      */
-    id?: string;
+    id: string;
     /**
      * 
      * @type {DocumentMeta}
      * @memberof DocumentListEntry
      */
-    meta?: DocumentMeta;
+    meta: DocumentMeta;
     /**
      * 
      * @type {Array<Label>}
      * @memberof DocumentListEntry
      */
-    labels?: Array<Label>;
+    labels: Array<Label>;
 }
 
 /**
@@ -1274,13 +1274,13 @@ export interface DocumentMeta {
      * @type {string}
      * @memberof DocumentMeta
      */
-    name?: string;
+    name: string;
     /**
      * 
      * @type {string}
      * @memberof DocumentMeta
      */
-    version?: string;
+    version: string;
 }
 
 /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -52,25 +52,17 @@ interface IKeyValuePairs {
   [key: string]: any
 }
 
-export interface ITemplate extends Document {
-  content: ITemplateContent
+// Templates
+interface ITemplateBase extends Document {
+  content: {data: ITemplateData; included: ITemplateIncluded[]}
   labels: ILabel[]
 }
 
-interface ITemplateContent {
-  data: ITemplateData
-  included: ITemplateIncluded[]
-}
-
+// TODO: be more specific about what attributes can be
 interface ITemplateData {
   type: TemplateType
   attributes: IKeyValuePairs
   relationships: {[key in TemplateType]?: {data: IRelationship[]}}
-}
-
-interface IRelationship {
-  type: TemplateType
-  id: string
 }
 
 interface ITemplateIncluded {
@@ -79,24 +71,12 @@ interface ITemplateIncluded {
   attributes: IKeyValuePairs
 }
 
-export interface ITaskTemplate extends ITemplate {
-  content: {
-    data: ITaskTemplateData
-    included: ITaskTemplateIncluded[]
-  }
-}
+// Template Relationships
+type IRelationship = ICellRelationship | ILabelRelationship | IViewRelationship
 
-interface ITaskTemplateData extends ITemplateData {
-  type: TemplateType.Task
-  attributes: {name: string; flux: string}
-  relationships: {
-    [TemplateType.Label]: {data: ILabelRelationship[]}
-  }
-}
-
-interface ITaskTemplateIncluded extends ITemplateIncluded {
-  type: TemplateType.Label
-  attributes: {name: string; properties: ILabelProperties}
+interface ICellRelationship {
+  type: TemplateType.Cell
+  id: string
 }
 
 export interface ILabelRelationship {
@@ -104,24 +84,15 @@ export interface ILabelRelationship {
   id: string
 }
 
-export interface ILabelIncluded extends ITemplateIncluded {
-  type: TemplateType.Label
-  attributes: {name: string; properties: ILabelProperties}
-}
-
 interface IViewRelationship {
   type: TemplateType.View
   id: string
 }
 
+// Template Includeds
 export interface IViewIncluded extends ITemplateIncluded {
   type: TemplateType.View
   attributes: View
-}
-
-interface ICellRelationship {
-  type: TemplateType.Cell
-  id: string
 }
 
 export interface ICellIncluded extends ITemplateIncluded {
@@ -132,10 +103,24 @@ export interface ICellIncluded extends ITemplateIncluded {
   }
 }
 
-export interface IDashboardTemplate extends ITemplate {
-  content: {
-    data: IDashboardTemplateData
-    included: IDashboardTemplateIncluded[]
+export interface ILabelIncluded extends ITemplateIncluded {
+  type: TemplateType.Label
+  attributes: ILabel
+}
+
+export type ITaskTemplateIncluded = ILabelIncluded
+
+export type IDashboardTemplateIncluded =
+  | ICellIncluded
+  | IViewIncluded
+  | ILabelIncluded
+
+// Template Datas
+interface ITaskTemplateData extends ITemplateData {
+  type: TemplateType.Task
+  attributes: {name: string; flux: string}
+  relationships: {
+    [TemplateType.Label]: {data: ILabelRelationship[]}
   }
 }
 
@@ -148,7 +133,19 @@ interface IDashboardTemplateData extends ITemplateData {
   }
 }
 
-export type IDashboardTemplateIncluded =
-  | ICellIncluded
-  | IViewIncluded
-  | ILabelIncluded
+// Templates
+export interface ITaskTemplate extends ITemplateBase {
+  content: {
+    data: ITaskTemplateData
+    included: ITaskTemplateIncluded[]
+  }
+}
+
+export interface IDashboardTemplate extends ITemplateBase {
+  content: {
+    data: IDashboardTemplateData
+    included: IDashboardTemplateIncluded[]
+  }
+}
+
+export type ITemplate = ITaskTemplate | IDashboardTemplate

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,4 @@
-import {Bucket, Cell, Dashboard, Task, Telegraf, View} from '../api'
+import {Bucket, Cell, Dashboard, Task, Telegraf, View, Document} from '../api'
 import {Label as APILabel} from '../api'
 
 export interface ILabelProperties {
@@ -52,27 +52,20 @@ interface IKeyValuePairs {
   [key: string]: any
 }
 
-export interface ITemplate {
-  id?: string
-  meta: ITemplateMeta
+export interface ITemplate extends Document {
   content: ITemplateContent
-  labels?: string[]
-}
-
-interface ITemplateMeta extends IKeyValuePairs {
-  name: string
-  version: string
+  labels: ILabel[]
 }
 
 interface ITemplateContent {
   data: ITemplateData
-  included?: ITemplateIncluded[]
+  included: ITemplateIncluded[]
 }
 
 interface ITemplateData {
   type: TemplateType
   attributes: IKeyValuePairs
-  relationships?: {[key in TemplateType]?: {data: IRelationship[]}}
+  relationships: {[key in TemplateType]?: {data: IRelationship[]}}
 }
 
 interface IRelationship {
@@ -89,14 +82,14 @@ interface ITemplateIncluded {
 export interface ITaskTemplate extends ITemplate {
   content: {
     data: ITaskTemplateData
-    included?: ITaskTemplateIncluded[]
+    included: ITaskTemplateIncluded[]
   }
 }
 
 interface ITaskTemplateData extends ITemplateData {
   type: TemplateType.Task
   attributes: {name: string; flux: string}
-  relationships?: {
+  relationships: {
     [TemplateType.Label]: {data: ILabelRelationship[]}
   }
 }
@@ -142,14 +135,14 @@ export interface ICellIncluded extends ITemplateIncluded {
 export interface IDashboardTemplate extends ITemplate {
   content: {
     data: IDashboardTemplateData
-    included?: IDashboardTemplateIncluded[]
+    included: IDashboardTemplateIncluded[]
   }
 }
 
 interface IDashboardTemplateData extends ITemplateData {
   type: TemplateType.Dashboard
   attributes: IDashboard
-  relationships?: {
+  relationships: {
     [TemplateType.Label]: {data: ILabelRelationship[]}
     [TemplateType.Cell]: {data: ICellRelationship[]}
   }

--- a/src/wrappers/templates.ts
+++ b/src/wrappers/templates.ts
@@ -1,4 +1,12 @@
 import {TemplatesApi, DocumentListEntry, Document, DocumentCreate} from '../api'
+import {ITemplate} from '../types'
+import {addLabelDefaults} from './labels'
+
+export const addTemplateDefaults = (d: Document): ITemplate => ({
+  ...d,
+  content: {data: {}, included: [], ...d.content},
+  labels: d.labels.map(addLabelDefaults),
+})
 
 export default class {
   private service: TemplatesApi
@@ -17,17 +25,17 @@ export default class {
     return []
   }
 
-  public async get(templateID: string): Promise<Document> {
+  public async get(templateID: string): Promise<ITemplate> {
     const {data} = await this.service.documentsTemplatesTemplateIDGet(
       templateID
     )
 
-    return data
+    return addTemplateDefaults(data)
   }
 
-  public async create(templateCreate: DocumentCreate): Promise<Document> {
+  public async create(templateCreate: DocumentCreate): Promise<ITemplate> {
     const {data} = await this.service.documentsTemplatesPost(templateCreate)
 
-    return data
+    return addTemplateDefaults(data)
   }
 }


### PR DESCRIPTION
Closes: https://github.com/influxdata/influxdb2-js/issues/38

- converted parameters of Document schema that are guaranteed to required 
(in https://github.com/influxdata/influxdb/pull/12637#event-2204931341)

- ITemplateBase extends Document, and specific templates Like IDashboardTemplate extend ITemplateBase, ITemplate is the union of the specific templates. 

- Convert Document types returned from API to ITemplate by applying defaults to optional params. 