### PR TITLE
Add guaranteed labels parameter to templates

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1202,7 +1202,7 @@ export interface Document {
      * @type {Array<Label>}
      * @memberof Document
      */
-    labels: Array<Label>;
+    labels?: Array<Label>;
 }
 
 /**
@@ -1266,7 +1266,7 @@ export interface DocumentListEntry {
      * @type {Array<Label>}
      * @memberof DocumentListEntry
      */
-    labels: Array<Label>;
+    labels?: Array<Label>;
 }
 
 /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -59,7 +59,7 @@ interface IKeyValuePairs {
 // Templates
 interface ITemplateBase extends Document {
   content: {data: ITemplateData; included: ITemplateIncluded[]}
-  labels: ILabel[]
+  labels?: ILabel[]
 }
 
 // TODO: be more specific about what attributes can be

--- a/src/wrappers/templates.ts
+++ b/src/wrappers/templates.ts
@@ -2,16 +2,22 @@ import {TemplatesApi, DocumentListEntry, Document, DocumentCreate} from '../api'
 import {ITemplate, TemplateSummary} from '../types'
 import {addLabelDefaults} from './labels'
 
-const addTemplateDefaults = (d: Document): ITemplate => ({
-  ...d,
-  content: {data: {}, included: [], ...d.content},
-  labels: d.labels.map(addLabelDefaults),
-})
+const addTemplateDefaults = (d: Document): ITemplate => {
+  const labels = d.labels || []
+  return {
+    ...d,
+    content: {data: {}, included: [], ...d.content},
+    labels: labels.map(addLabelDefaults),
+  }
+}
 
-const addTemplateSummaryDefaults = (d: DocumentListEntry): TemplateSummary => ({
-  ...d,
-  labels: d.labels.map(addLabelDefaults),
-})
+const addTemplateSummaryDefaults = (d: DocumentListEntry): TemplateSummary => {
+  const labels = d.labels || []
+  return {
+    ...d,
+    labels: labels.map(addLabelDefaults),
+  }
+}
 
 export default class {
   private service: TemplatesApi


### PR DESCRIPTION
Turns out labels are not guaranteed on documents, adjusted swagger back, and added defaults in a way that doesn't require labels to work. 