### PR TITLE
Update telegraf and dashboard labels to remove multiple

### DIFF
--- a/src/wrappers/dashboards.ts
+++ b/src/wrappers/dashboards.ts
@@ -182,6 +182,15 @@ export default class {
     return data
   }
 
+  public removeLabels(
+    dashboardID: string,
+    labelIDs: string[]
+  ): Promise<Response[]> {
+    const promises = labelIDs.map(l => this.removeLabel(dashboardID, l))
+
+    return Promise.all(promises)
+  }
+
   public async getView(dashboardID: string, cellID: string): Promise<View> {
     const {data} = await this.service.dashboardsDashboardIDCellsCellIDViewGet(
       dashboardID,

--- a/src/wrappers/telegrafConfigs.ts
+++ b/src/wrappers/telegrafConfigs.ts
@@ -103,12 +103,6 @@ export default class {
     return addLabelDefaults(data.label)
   }
 
-  public async addLabels(id: string, labels: ILabel[]): Promise<ILabel[]> {
-    const pendingLabels = labels.map(l => this.addLabel(id, l))
-
-    return Promise.all(pendingLabels)
-  }
-
   public async removeLabel(id: string, label: ILabel): Promise<Response> {
     if (!label.id) {
       throw new Error('label must have id')
@@ -120,5 +114,17 @@ export default class {
     )
 
     return data
+  }
+
+  public async addLabels(id: string, labels: ILabel[]): Promise<ILabel[]> {
+    const pendingLabels = labels.map(l => this.addLabel(id, l))
+
+    return Promise.all(pendingLabels)
+  }
+
+  public async removeLabels(id: string, labels: ILabel[]): Promise<Response[]> {
+    const promises = labels.map(l => this.removeLabel(id, l))
+
+    return Promise.all(promises)
   }
 }


### PR DESCRIPTION
Telegraf and dashboard wrappers had removeLabel which took a Label object. Updated these wrappers to have a function that take an array of Label and remove multiple.