### PR TITLE
fix(wrapper/variable.labels): ensure defaults and labels

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -42,6 +42,10 @@ export interface ITelegraf extends Telegraf {
   labels: ILabel[]
 }
 
+export interface IVariable extends Variable {
+  labels: ILabel[]
+}
+
 type DashboardPicked = Pick<Dashboard, 'orgID' | 'id' | 'name' | 'cells'>
 type DashboardOriginal = Pick<
   Dashboard,


### PR DESCRIPTION
Closes #81 

__Briefly Describe Your Changes__

The client returned variables that were potentially undefined and did not check/apply defaults to each resource's label. This is important for ensuring `variable.labels[].properties` is not `any` and  has both `color: string` and `description?: string`.

Note: this is becoming a pain to catch and update in the client. We may want to consider some alternative/easier way of checking this for labeled resources.