### PR TITLE
fix(wrappers/template.labels): require labels array

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -69,7 +69,7 @@ interface IKeyValuePairs {
 // Templates
 interface ITemplateBase extends Document {
   content: {data: ITemplateData; included: ITemplateIncluded[]}
-  labels?: ILabel[]
+  labels: ILabel[]
 }
 
 // TODO: be more specific about what attributes can be


### PR DESCRIPTION
Closes #79

__Briefly Describe Your Changes__
The `ITemplateBase` allows for labels to be optional but the client was doing the work to add the defaults and ensure they exist. This change requires labels. Tried changing this in the ui locally and didn't get any linting/testing errors.  