### PR TITLE
fix(wrappers/vars.getall): return IVar array

### DIFF
--- a/src/wrappers/variables.ts
+++ b/src/wrappers/variables.ts
@@ -44,7 +44,7 @@ export default class {
     return (variables || []).map(v => addDefaults(v))
   }
 
-  public async getAll(orgID?: string): Promise<Variable[]> {
+  public async getAll(orgID?: string): Promise<IVariable[]> {
     const {
       data: {variables},
     } = await this.service.variablesGet(undefined, undefined, orgID)


### PR DESCRIPTION
The `variables.getAll` returns type `Variable[]` instead of `IVariable` this changes fixes that to make it consistent with other methods.