### PR TITLE
fix(types/template): add variable template

### DIFF
--- a/dist/types/index.d.ts
+++ b/dist/types/index.d.ts
@@ -108,6 +108,7 @@ export interface IVariableIncluded extends ITemplateIncluded {
 }
 export declare type ITaskTemplateIncluded = ILabelIncluded;
 export declare type IDashboardTemplateIncluded = ICellIncluded | IViewIncluded | ILabelIncluded | IVariableIncluded;
+export declare type IVariableTemplateIncluded = IVariableIncluded | ILabelIncluded;
 interface ITaskTemplateData extends ITemplateData {
     type: TemplateType.Task;
     attributes: {
@@ -135,6 +136,18 @@ interface IDashboardTemplateData extends ITemplateData {
         };
     };
 }
+interface VariableTemplateData extends ITemplateData {
+    type: TemplateType.Variable;
+    attributes: Omit<Variable, 'labels' | 'links'>;
+    relationships: {
+        [TemplateType.Label]: {
+            data: ILabelRelationship[];
+        };
+        [TemplateType.Variable]: {
+            data: IVariableRelationship[];
+        };
+    };
+}
 export interface ITaskTemplate extends ITemplateBase {
     content: {
         data: ITaskTemplateData;
@@ -147,8 +160,15 @@ export interface IDashboardTemplate extends ITemplateBase {
         included: IDashboardTemplateIncluded[];
     };
 }
-export declare type ITemplate = ITaskTemplate | IDashboardTemplate;
+export interface IVariableTemplate extends ITemplateBase {
+    content: {
+        data: VariableTemplateData;
+        included: IVariableTemplateIncluded[];
+    };
+}
+export declare type ITemplate = ITaskTemplate | IDashboardTemplate | IVariableTemplate;
 export interface TemplateSummary extends DocumentListEntry {
     labels: ILabel[];
 }
+declare type Omit<K, V> = Pick<K, Exclude<keyof K, V>>;
 export {};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -148,6 +148,8 @@ export type IDashboardTemplateIncluded =
   | ILabelIncluded
   | IVariableIncluded
 
+export type IVariableTemplateIncluded = IVariableIncluded | ILabelIncluded
+
 // Template Datas
 interface ITaskTemplateData extends ITemplateData {
   type: TemplateType.Task
@@ -167,6 +169,15 @@ interface IDashboardTemplateData extends ITemplateData {
   }
 }
 
+interface VariableTemplateData extends ITemplateData {
+  type: TemplateType.Variable
+  attributes: Omit<Variable, 'labels' | 'links'>
+  relationships: {
+    [TemplateType.Label]: {data: ILabelRelationship[]}
+    [TemplateType.Variable]: {data: IVariableRelationship[]}
+  }
+}
+
 // Templates
 export interface ITaskTemplate extends ITemplateBase {
   content: {
@@ -182,8 +193,17 @@ export interface IDashboardTemplate extends ITemplateBase {
   }
 }
 
-export type ITemplate = ITaskTemplate | IDashboardTemplate
+export interface IVariableTemplate extends ITemplateBase {
+  content: {
+    data: VariableTemplateData
+    included: IVariableTemplateIncluded[]
+  }
+}
+
+export type ITemplate = ITaskTemplate | IDashboardTemplate | IVariableTemplate
 
 export interface TemplateSummary extends DocumentListEntry {
   labels: ILabel[]
 }
+
+type Omit<K, V> = Pick<K, Exclude<keyof K, V>>


### PR DESCRIPTION
closes #92 

__Briefly describe your changes__
Adds the template variable type to `ITemplate` so we can handle importing variables retrieved using `templates.get`. This will resolve variable template type errors in ui for `createResourceFromTemplate` in the ui.